### PR TITLE
feat: switch to 7zz ahead of CVE-2025-55188 fixes

### DIFF
--- a/home/profiles/shell/default.nix
+++ b/home/profiles/shell/default.nix
@@ -19,7 +19,7 @@
 
       curl
       wget
-      (p7zip.override { enableUnfree = true; })
+      (_7zz.override { enableUnfree = true; })
 
       ldns
       mtr

--- a/nixos/modules/nix.nix
+++ b/nixos/modules/nix.nix
@@ -6,7 +6,7 @@
     pkg:
     builtins.elem (lib.getName pkg) [
       "discord"
-      "p7zip"
+      "7zz"
     ]
   );
 

--- a/systems/funi/home/shell.nix
+++ b/systems/funi/home/shell.nix
@@ -12,7 +12,7 @@
 
     curl
     wget
-    (p7zip.override { enableUnfree = true; })
+    (_7zz.override { enableUnfree = true; })
 
     ethtool
     iw


### PR DESCRIPTION
Wait for NixOS/nixpkgs#432581